### PR TITLE
Fix error reporting on Alt, SqlNull decodes

### DIFF
--- a/beam-mysql.cabal
+++ b/beam-mysql.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          beam-mysql
-version:       1.0.0.0
+version:       1.0.0.1
 synopsis:      Connection layer between beam and MySQL/MariaDB
 description:
   Beam driver for MySQL or MariaDB databases, two popular open-source databases.

--- a/src/Database/Beam/MySQL/FromField.hs
+++ b/src/Database/Beam/MySQL/FromField.hs
@@ -181,9 +181,17 @@ instance (FromField a) => FromField (Maybe a) where
     _         -> Just <$> fromField t v
 
 instance FromField SqlNull where
-  fromField _ = \case
+  fromField t v = case v of
     MySQLNull -> pure SqlNull
-    _         -> Left . ColumnErrorInternal $ "Unexpected non-NULL"
+    _         -> Left errorMsg
+    where
+      errorMsg :: ColumnParseError
+      errorMsg = ColumnTypeMismatch "Present value" "NULL" msg
+      msg :: String
+      msg = "Unexpected actual value of type" <>
+            fieldTypeToString t <>
+            " with value " <>
+            show v
 
 instance FromField ByteString where
   fromField t = \case


### PR DESCRIPTION
This ensures proper reporting of `SqlNull` encoding errors, as well as correct handling of errors in `Alt`.