### PR TITLE
Update Select.hs

### DIFF
--- a/src/Database/Beam/MySQL/Syntax/Select.hs
+++ b/src/Database/Beam/MySQL/Syntax/Select.hs
@@ -1,5 +1,7 @@
 -- Due to RDP plugin.
 {-# OPTIONS_GHC -Wno-incomplete-record-updates #-}
+{-# OPTIONS_GHC -Wwarn -Wambiguous-fields #-}
+
 {-# LANGUAGE TypeFamilies #-}
 
 module Database.Beam.MySQL.Syntax.Select where


### PR DESCRIPTION
Makes the `-Wambiguous-fields` a warning instead of an error.

That helps build this with the newer GHC 9.2.5