### PR TITLE
Implemented instance for BeamHasInsertOnConflict and support for INSERT on Conflict

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -30,7 +30,7 @@ let
 linuxBuildTools = with super; lib.optionals (!isDarwin) [ mysql57 numactl ];
 dontCheckDarwin =
   if isDarwin then super.haskell.lib.dontCheck else x: x;
-in 
+in
 super.eulerBuild.mkEulerHaskellOverlay self super
   (hself: hsuper: {
     record-dot-preprocessor = self.eulerBuild.fastBuildExternal {

--- a/src/Database/Beam/MySQL/Connection.hs
+++ b/src/Database/Beam/MySQL/Connection.hs
@@ -338,7 +338,7 @@ instance Beam.BeamHasInsertOnConflict MySQL where
     MySQLConflictAction $ \table ->
       let QAssignment assignments = makeAssignments table fieldsAliased
           fieldsAliased = changeBeamRep (\(Columnar' (QField _ _ nm)) -> Columnar' (QExpr (\_ -> fieldE (qualifiedField "new_values" nm)))) table
-      in ON_DUPLICATE_KEY_UPDATE $ V.fromList [ FieldUpdate fieldNm expr | (fieldNm, expr) <- assignments]
+      in UPDATE_ON_DUPLICATE_KEY $ V.fromList [FieldUpdate fieldNm expr | (fieldNm, expr) <- assignments]
   onConflictUpdateSetWhere _ _ = error "MySQL does not support UPDATE_SET with WHERE"
 
 -- | Some possible (but predictable) failure modes of this backend.

--- a/src/Database/Beam/MySQL/Connection.hs
+++ b/src/Database/Beam/MySQL/Connection.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE Trustworthy         #-}
 {-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE RankNTypes          #-}
 
 module Database.Beam.MySQL.Connection where
 
@@ -18,6 +19,7 @@ import           Control.Monad.RWS.Strict (RWST, evalRWST)
 import           Control.Monad.Reader (MonadReader (ask), ReaderT (..), asks,
                                        runReaderT)
 import           Control.Monad.State.Strict (MonadState (get), modify)
+import           Control.Monad.Writer (execWriter, tell)
 import           Data.Aeson (FromJSON)
 import           Data.ByteString (ByteString)
 import           Data.FakeUTC (FakeUTC)
@@ -35,12 +37,16 @@ import           Data.Vector (Vector)
 import qualified Data.Vector as V
 import           Data.ViaJson (ViaJson)
 import           Data.Word (Word16, Word32, Word64, Word8)
-import           Database.Beam.Backend (BeamBackend (..), BeamSqlBackend,
-                                        BeamSqlBackendSyntax,
-                                        FromBackendRow (..),
-                                        FromBackendRowF (..),
-                                        FromBackendRowM (..), MonadBeam (..))
-import           Database.Beam.Backend.SQL (BeamSqlBackendIsString, SqlNull)
+import           Database.Beam.Backend
+import qualified Database.Beam.Backend.SQL.BeamExtensions as Beam
+import           Database.Beam.Schema.Tables ( Beamable
+                                             , Columnar'(..)
+                                             , DatabaseEntity(..)
+                                             , DatabaseEntityDescriptor(..)
+                                             , TableEntity
+                                             , TableField(..)
+                                             , changeBeamRep )
+import           Database.Beam.Query.Internal
 import           Database.Beam.MySQL.FromField.DecodeError (DecodeError (DecodeError),
                                                             Lenient (IEEEInfinity, IEEENaN, IEEETooBig, IEEETooSmall, SomeStrict, TextCouldNotParse),
                                                             Strict (NotValidJSON, TypeMismatch, UnexpectedNull, Won'tFit))
@@ -55,8 +61,13 @@ import           Database.Beam.MySQL.FromField.Lenient (FromField (fromField))
 import           Database.Beam.MySQL.FromField.Strict (FromField (fromField))
 #endif
 import           Database.Beam.MySQL.Syntax (MySQLSyntax (..))
-import           Database.Beam.Query (HasQBuilder (..), HasSqlEqualityCheck,
-                                      HasSqlQuantifiedEqualityCheck)
+import           Database.Beam.MySQL.Syntax.Insert ( MySQLInsert(InsertStmt)
+                                                    , MySQLInsertOnConflictAction(..)
+                                                    , MySQLInsertOnConflictTarget(..) )
+import           Database.Beam.MySQL.Syntax.Update ( FieldUpdate(FieldUpdate) )
+import           Database.Beam.Query ( SqlInsert(..), SqlInsertValues(..)
+                                     , HasQBuilder(..), HasSqlEqualityCheck
+                                     , HasSqlQuantifiedEqualityCheck)
 import           Database.Beam.Query.SQL92 (buildSql92Query')
 import           Database.MySQL.Base (ColumnDef, MySQLConn, MySQLValue (..),
                                       Query (..), columnOrigName, columnType,
@@ -291,6 +302,44 @@ instance HasSqlEqualityCheck MySQL FakeUTC
 
 -- | @since 1.2.2.0
 instance HasSqlQuantifiedEqualityCheck MySQL FakeUTC
+
+instance Beam.BeamHasInsertOnConflict MySQL where
+  newtype SqlConflictTarget MySQL table = MySQLConflictTarget
+    { unMySQLConflictTarget :: table (QExpr MySQL QInternal) -> MySQLInsertOnConflictTarget }
+  newtype SqlConflictAction MySQL table = MySQLConflictAction
+    { unMySQLConflictAction :: forall s. table (QField s) -> MySQLInsertOnConflictAction }
+
+  insertOnConflict
+    :: forall db table s. Beamable table
+    => DatabaseEntity MySQL db (TableEntity table)
+    -> SqlInsertValues MySQL (table (QExpr MySQL s))
+    -> Beam.SqlConflictTarget MySQL table
+    -> Beam.SqlConflictAction MySQL table
+    -> SqlInsert MySQL table
+  insertOnConflict (DatabaseEntity dt) vals _ action = case vals of
+    SqlInsertValuesEmpty -> SqlInsertNoRows
+    SqlInsertValues vs   -> SqlInsert (dbTableSettings dt) $ 
+      let getFieldName
+            :: forall a
+            .  Columnar' (TableField table) a
+            -> Columnar' (QField QInternal) a
+          getFieldName (Columnar' fd) = Columnar' $ QField False (dbTableCurrentName dt) $ _fieldName fd
+          tableFields = changeBeamRep getFieldName $ dbTableSettings dt
+          tellFieldName _ _ f = tell [f] >> pure f
+          fieldNames = execWriter $ project' (Proxy @AnyType) (Proxy @((), Text)) tellFieldName tableFields
+        in InsertStmt (tableNameFromEntity dt) (V.fromList fieldNames) vs (Just $ unMySQLConflictAction action tableFields)
+
+  anyConflict = MySQLConflictTarget (const MySQLInsertOnConflictAnyTarget)
+  conflictingFields _ = error "MySQL does not support CONFLICT_TARGETS"
+  conflictingFieldsWhere _ _ = error "MySQL does not support CONFLICT_TARGETS with WHERE"
+
+  onConflictDoNothing = MySQLConflictAction (const IGNORE)
+  onConflictUpdateSet makeAssignments = 
+    MySQLConflictAction $ \table ->
+      let QAssignment assignments = makeAssignments table fieldsAliased
+          fieldsAliased = changeBeamRep (\(Columnar' (QField _ _ nm)) -> Columnar' (QExpr (\_ -> fieldE (qualifiedField "new_values" nm)))) table
+      in ON_DUPLICATE_KEY_UPDATE $ V.fromList [ FieldUpdate fieldNm expr | (fieldNm, expr) <- assignments]
+  onConflictUpdateSetWhere _ _ = error "MySQL does not support UPDATE_SET with WHERE"
 
 -- | Some possible (but predictable) failure modes of this backend.
 --

--- a/src/Database/Beam/MySQL/Syntax/Insert.hs
+++ b/src/Database/Beam/MySQL/Syntax/Insert.hs
@@ -50,7 +50,7 @@ data MySQLInsert = InsertStmt
 data MySQLInsertOnConflictTarget = MySQLInsertOnConflictAnyTarget
 data MySQLInsertOnConflictAction 
   = IGNORE
-  | ON_DUPLICATE_KEY_UPDATE !(Vector FieldUpdate)
+  | UPDATE_ON_DUPLICATE_KEY !(Vector FieldUpdate)
   deriving stock (Eq, Show)
 
 instance IsSql92InsertSyntax MySQLInsert where

--- a/src/Database/Beam/MySQL/Syntax/Insert.hs
+++ b/src/Database/Beam/MySQL/Syntax/Insert.hs
@@ -10,6 +10,7 @@ import           Database.Beam.MySQL.Syntax.Select (MySQLExpressionSyntax,
                                                     MySQLSelect,
                                                     MySQLTableNameSyntax,
                                                     TableRowExpression (TableRowExpression))
+import           Database.Beam.MySQL.Syntax.Update (FieldUpdate)
 
 -- | Representation of @VALUES@ in an @INSERT@.
 --
@@ -38,11 +39,18 @@ instance IsSql92InsertValuesSyntax MySQLInsertValuesSyntax where
   insertFromSql :: MySQLSelect -> MySQLInsertValuesSyntax
   insertFromSql = InsertFromSQL
 
-data MySQLInsert = InsertStmt {
-  tableName    :: {-# UNPACK #-} !MySQLTableNameSyntax,
-  columns      :: {-# UNPACK #-} !(Vector Text),
-  insertValues :: MySQLInsertValuesSyntax
+data MySQLInsert = InsertStmt 
+  { tableName    :: {-# UNPACK #-} !MySQLTableNameSyntax
+  , columns      :: {-# UNPACK #-} !(Vector Text)
+  , insertValues :: MySQLInsertValuesSyntax
+  , onConflict   :: !(Maybe MySQLInsertOnConflictAction)
   }
+  deriving stock (Eq, Show)
+
+data MySQLInsertOnConflictTarget = MySQLInsertOnConflictAnyTarget
+data MySQLInsertOnConflictAction 
+  = IGNORE
+  | ON_DUPLICATE_KEY_UPDATE !(Vector FieldUpdate)
   deriving stock (Eq, Show)
 
 instance IsSql92InsertSyntax MySQLInsert where
@@ -56,6 +64,5 @@ instance IsSql92InsertSyntax MySQLInsert where
     [Text] ->
     MySQLInsertValuesSyntax ->
     MySQLInsert
-  insertStmt tableName' columns' =
-    InsertStmt tableName'
-               (fromList columns')
+  insertStmt tableName' columns' insertValues' =
+    InsertStmt tableName' (fromList columns') insertValues' Nothing

--- a/src/Database/Beam/MySQL/Syntax/Render.hs
+++ b/src/Database/Beam/MySQL/Syntax/Render.hs
@@ -24,6 +24,7 @@ import           Database.Beam.MySQL.Syntax.DataType (MySQLDataTypeSyntax (..),
                                                       MySQLPrecision (..))
 import           Database.Beam.MySQL.Syntax.Delete (MySQLDelete)
 import           Database.Beam.MySQL.Syntax.Insert (MySQLInsert,
+                                                    MySQLInsertOnConflictAction (..),
                                                     MySQLInsertValuesSyntax (..))
 import           Database.Beam.MySQL.Syntax.Misc (MySQLAggregationSetQuantifierSyntax (..),
                                                   MySQLExtractFieldSyntax (..),
@@ -487,14 +488,23 @@ renderOrdering = \case
 
 renderInsert' :: MySQLInsert -> RenderM Builder
 renderInsert' ins = do
+  let insertBegin = maybe ("INSERT INTO " :: Builder) renderInsertIgnore ins.onConflict
   tableName' <- renderTableName ins.tableName
   insertValues' <- renderInsertValues ins.insertValues
+  onDuplicateKeyUpdate <- maybe (pure "") renderOnDuplicateKeyUpdate ins.onConflict  
   pure $
-    "INSERT INTO " <>
+    insertBegin <>
     tableName' <>
     " " <>
     (bracketWrap . intersperse ", " . toList . fmap (backtickWrap . textUtf8) $ ins.columns) <>
-    insertValues'
+    insertValues' <>
+    onDuplicateKeyUpdate
+
+renderInsertIgnore :: MySQLInsertOnConflictAction -> Builder
+renderInsertIgnore action = do
+  case action of
+    IGNORE -> "INSERT IGNORE INTO "
+    _      -> "INSERT INTO "
 
 renderInsertValues :: MySQLInsertValuesSyntax -> RenderM Builder
 renderInsertValues = \case
@@ -502,6 +512,14 @@ renderInsertValues = \case
     rti' <- traverse renderTableRow rti
     pure $ " VALUES " <> (intersperse ", " . toList . fmap bracketWrap $ rti')
   InsertFromSQL sel -> renderSelect' sel
+
+renderOnDuplicateKeyUpdate :: MySQLInsertOnConflictAction -> RenderM Builder
+renderOnDuplicateKeyUpdate action = do
+  case action of
+    ON_DUPLICATE_KEY_UPDATE updates -> do
+      updates' <- traverse renderFieldUpdate updates
+      pure $ " AS new_values" <> if Data.Vector.length updates' == 0 then mempty else " ON DUPLICATE KEY UPDATE " <> (intersperse ", " . toList $ updates')
+    _                               -> pure ""
 
 renderUpdate' :: MySQLUpdate -> RenderM Builder
 renderUpdate' upd = do

--- a/src/Database/Beam/MySQL/Syntax/Render.hs
+++ b/src/Database/Beam/MySQL/Syntax/Render.hs
@@ -516,10 +516,10 @@ renderInsertValues = \case
 renderOnDuplicateKeyUpdate :: MySQLInsertOnConflictAction -> RenderM Builder
 renderOnDuplicateKeyUpdate action = do
   case action of
-    ON_DUPLICATE_KEY_UPDATE updates -> do
+    UPDATE_ON_DUPLICATE_KEY updates -> do
       updates' <- traverse renderFieldUpdate updates
       pure $ " AS new_values" <> if Data.Vector.length updates' == 0 then mempty else " ON DUPLICATE KEY UPDATE " <> (intersperse ", " . toList $ updates')
-    _                               -> pure ""
+    _                               -> pure mempty
 
 renderUpdate' :: MySQLUpdate -> RenderM Builder
 renderUpdate' upd = do


### PR DESCRIPTION
- Implemented instance for BeamHasInsertOnConflict in beam-mysql
- Added support for INSERT on Conflict in beam-mysql
- Made INSERT render changes to support the above changes

Test cases:
> Following are the functions that I wrote functions in `euler-hs` to test the query generation
1. `sqlMultiCreate value = BExt.insertOnConflict modelTableEntity (mkMultiExprWithDefault value) BExt.anyConflict BExt.onConflictDoNothing`

>Query generated:
```INSERT IGNORE INTO `table_name` (`field`, ...) VALUES (value, ...);```

2. `sqlMultiCreate' value updates = BExt.insertOnConflict modelTableEntity (mkMultiExprWithDefault value) BExt.anyConflict $ BExt.onConflictUpdateSet updates`

Cases tried as argument to `updates` parameter:

> Case 1:
`(\fields newValues -> (bankCode fields <-. val_ (Just "RANDOM"))))`
Query generated:
```INSERT INTO `table_name` (`field`, ...) VALUES (value, ...) AS new_values ON DUPLICATE KEY UPDATE `bank_code`='RANDOM';```

> Case 2:
`(\fields newValues -> (bankCode fields <-. val_ (Just "RANDOM")) <> (version fields <-. version newValues)))`
Query generated:
```INSERT INTO `table_name` (`field`, ...) VALUES (value, ...) AS new_values ON DUPLICATE KEY UPDATE `bank_code`='RANDOM', `version`=`new_values`.`version`;```




