### PR TITLE
Mobility/ghc-9.2.5 work

### DIFF
--- a/beam-mysql.cabal
+++ b/beam-mysql.cabal
@@ -28,7 +28,7 @@ source-repository head
 common common-lang
   ghc-options:
     -Wall -Wcompat -Wincomplete-record-updates
-    -Wincomplete-uni-patterns -Wredundant-constraints -Werror
+    -Wincomplete-uni-patterns -Wredundant-constraints -Werror -Wwarn=ambiguous-fields
     -fplugin=RecordDotPreprocessor
 
   build-depends:

--- a/beam-mysql.cabal
+++ b/beam-mysql.cabal
@@ -33,14 +33,14 @@ common common-lang
 
   build-depends:
     , base                     >=4.13     && <5
-    , beam-core                ^>=0.9.0.0
-    , generics-sop             ^>=0.5.1.0
-    , mysql-haskell            ^>=0.8.4.2
-    , record-dot-preprocessor  ^>=0.2.7
-    , record-hasfield          ^>=1.0
-    , safe-exceptions          ^>=0.1.7.0
-    , text                     ^>=1.2.4.0
-    , unordered-containers     ^>=0.2.10.0
+    , beam-core
+    , generics-sop
+    , mysql-haskell
+    , record-dot-preprocessor
+    , record-hasfield
+    , safe-exceptions
+    , text
+    , unordered-containers
 
   default-extensions:
     DataKinds
@@ -70,7 +70,7 @@ common common-test
   build-depends:
     , beam-mysql
     , db
-    , tasty       ^>=1.4.1
+    , tasty
 
 -- Flags
 
@@ -132,22 +132,22 @@ library
       Database.Beam.MySQL.Utils
 
   build-depends:
-    , aeson            ^>=1.4.7.1 || ^>=1.5.0.0
-    , binary           ^>=0.8.7.0
-    , bytestring       ^>=0.10.10.0
-    , fmt              ^>=0.6.1.2
-    , free             ^>=5.1.3
-    , hashable         ^>=1.3.0.0
-    , int-cast         ^>=0.2.0.0
-    , io-streams       ^>=1.5.1.0
-    , mason            ^>=0.2.3
-    , mtl              ^>=2.2.2
-    , mysql-haskell    ^>=0.8.4.2
-    , safe-exceptions  ^>=0.1.7.0
-    , scientific       ^>=0.3.6.2
-    , text             ^>=1.2.4.0
-    , time             ^>=1.9.3
-    , vector           ^>=0.12.1.2
+    , aeson
+    , binary
+    , bytestring
+    , fmt
+    , free
+    , hashable
+    , int-cast
+    , io-streams
+    , mason
+    , mtl
+    , mysql-haskell
+    , safe-exceptions
+    , scientific
+    , text
+    , time
+    , vector
 
   if flag(lenient)
     cpp-options: -DLENIENT
@@ -190,9 +190,9 @@ library pool
   exposed-modules: Pool
   build-depends:
     , BoundedChan
-    , lifted-base        ^>=0.2.3.12
-    , monad-control      ^>=1.0.2.3
-    , transformers-base  ^>=0.4.5.2
+    , lifted-base
+    , monad-control
+    , transformers-base
 
   hs-source-dirs:  pool
 
@@ -207,7 +207,7 @@ test-suite generation
   main-is:        Main.hs
   build-depends:
     , aeson
-    , tasty-hunit  ^>=0.10.0.3
+    , tasty-hunit
 
   hs-source-dirs: test/generation
 
@@ -234,11 +234,11 @@ test-suite via-json
   main-is:        Main.hs
   build-depends:
     , aeson
-    , hedgehog        ^>=1.0.5
+    , hedgehog
     , lifted-base
     , pool
     , scientific
-    , tasty-hedgehog  ^>=1.1.0.0
+    , tasty-hedgehog
     , vector
 
   hs-source-dirs: test/via-json
@@ -265,7 +265,7 @@ test-suite unicode
   main-is:        Main.hs
   build-depends:
     , fmt
-    , split        ^>=0.2.3.4
+    , split
     , tasty-hunit
 
   hs-source-dirs: test/unicode

--- a/src/Database/Beam/MySQL/Syntax/Select.hs
+++ b/src/Database/Beam/MySQL/Syntax/Select.hs
@@ -1,5 +1,7 @@
 -- Due to RDP plugin.
 {-# OPTIONS_GHC -Wno-incomplete-record-updates #-}
+{-# OPTIONS_GHC -Wwarn -Wambiguous-fields #-}
+
 {-# LANGUAGE TypeFamilies #-}
 
 module Database.Beam.MySQL.Syntax.Select where

--- a/src/Database/Beam/MySQL/Syntax/Select.hs
+++ b/src/Database/Beam/MySQL/Syntax/Select.hs
@@ -1,6 +1,5 @@
 -- Due to RDP plugin.
 {-# OPTIONS_GHC -Wno-incomplete-record-updates #-}
-{-# OPTIONS_GHC -Wwarn -Wambiguous-fields #-}
 
 {-# LANGUAGE TypeFamilies #-}
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,15 @@
+resolver: lts-20.4
+allow-newer: true
+system-ghc: true
+
+packages:
+  - .
+
+extra-deps:
+  - git: https://github.com/winterland1989/word24.git
+    commit: 445f791e35ddc8098f05879dbcd07c41b115cb39
+
+  - int-cast-0.2.0.0@sha256:06820c1c5335100c5021e01314cd498e4d248582622c36d8e7203fa4341cb6d0,1668
+  - mysql-haskell-0.8.4.3@sha256:d3ca21ae8cc88670f8adb17c7cacb8bb770f1a58d60b5bff346d1f3fc843d98c,3489
+  - binary-parsers-0.2.4.0@sha256:8c3a436df2d721cb3268c3c56f9ce982bc5dbcd6e6db4cce24e96d1d48078678,3595
+  - wire-streams-0.1.1.0@sha256:08816c7fa53b20f52e5c465252c106d9de8e6d9580ec0b6d9f000a34c7bcefc8,2130

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.4
+resolver: lts-20.11
 allow-newer: true
 system-ghc: true
 


### PR DESCRIPTION
This PR enables the repo to work & build with newest lts-20.11 resolver, which comes with new GHC version 9.2.5 for the Mobility set of projects.

This repo is a depedency on the Mobility set of projects and this branch tracks the same.

This branch should run as it's own thing and not to be merged back into master for now.