### PR TITLE
GHC upgrade

### DIFF
--- a/beam-mysql.cabal
+++ b/beam-mysql.cabal
@@ -28,19 +28,19 @@ source-repository head
 common common-lang
   ghc-options:
     -Wall -Wcompat -Wincomplete-record-updates
-    -Wincomplete-uni-patterns -Wredundant-constraints -Werror
+    -Wincomplete-uni-patterns -Wredundant-constraints -Werror -Wwarn -Wambiguous-fields
     -fplugin=RecordDotPreprocessor
 
   build-depends:
-    , base                     >=4.13     && <5
-    , beam-core                ^>=0.9.0.0
-    , generics-sop             ^>=0.5.1.0
-    , mysql-haskell            ^>=0.8.4.2
-    , record-dot-preprocessor  ^>=0.2.7
-    , record-hasfield          ^>=1.0
-    , safe-exceptions          ^>=0.1.7.0
-    , text                     ^>=1.2.4.0
-    , unordered-containers     ^>=0.2.10.0
+    , base                     
+    , beam-core                
+    , generics-sop             
+    , mysql-haskell            
+    , record-dot-preprocessor  
+    , record-hasfield          
+    , safe-exceptions          
+    , text                     
+    , unordered-containers     
 
   default-extensions:
     DataKinds
@@ -70,7 +70,7 @@ common common-test
   build-depends:
     , beam-mysql
     , db
-    , tasty       ^>=1.4.1
+    , tasty       
 
 -- Flags
 
@@ -132,22 +132,22 @@ library
       Database.Beam.MySQL.Utils
 
   build-depends:
-    , aeson            ^>=1.4.7.1 || ^>=1.5.0.0
-    , binary           ^>=0.8.7.0
-    , bytestring       ^>=0.10.10.0
-    , fmt              ^>=0.6.1.2
-    , free             ^>=5.1.3
-    , hashable         ^>=1.3.0.0
-    , int-cast         ^>=0.2.0.0
-    , io-streams       ^>=1.5.1.0
-    , mason            ^>=0.2.3
-    , mtl              ^>=2.2.2
-    , mysql-haskell    ^>=0.8.4.2
-    , safe-exceptions  ^>=0.1.7.0
-    , scientific       ^>=0.3.6.2
-    , text             ^>=1.2.4.0
-    , time             ^>=1.9.3
-    , vector           ^>=0.12.1.2
+    , aeson            
+    , binary           
+    , bytestring       
+    , fmt              
+    , free             
+    , hashable         
+    , int-cast         
+    , io-streams       
+    , mason            
+    , mtl              
+    , mysql-haskell    
+    , safe-exceptions  
+    , scientific       
+    , text             
+    , time             
+    , vector           
 
   if flag(lenient)
     cpp-options: -DLENIENT
@@ -190,9 +190,9 @@ library pool
   exposed-modules: Pool
   build-depends:
     , BoundedChan
-    , lifted-base        ^>=0.2.3.12
-    , monad-control      ^>=1.0.2.3
-    , transformers-base  ^>=0.4.5.2
+    , lifted-base        
+    , monad-control      
+    , transformers-base  
 
   hs-source-dirs:  pool
 
@@ -207,7 +207,7 @@ test-suite generation
   main-is:        Main.hs
   build-depends:
     , aeson
-    , tasty-hunit  ^>=0.10.0.3
+    , tasty-hunit  
 
   hs-source-dirs: test/generation
 
@@ -234,11 +234,11 @@ test-suite via-json
   main-is:        Main.hs
   build-depends:
     , aeson
-    , hedgehog        ^>=1.0.5
+    , hedgehog        
     , lifted-base
     , pool
     , scientific
-    , tasty-hedgehog  ^>=1.1.0.0
+    , tasty-hedgehog  
     , vector
 
   hs-source-dirs: test/via-json
@@ -265,7 +265,7 @@ test-suite unicode
   main-is:        Main.hs
   build-depends:
     , fmt
-    , split        ^>=0.2.3.4
+    , split        
     , tasty-hunit
 
   hs-source-dirs: test/unicode
@@ -320,7 +320,7 @@ test-suite leniency
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
   build-depends:
-    , ieee754      ^>=0.8.0
+    , ieee754      
     , tasty-hunit
     , vector
 

--- a/euler.yaml
+++ b/euler.yaml
@@ -6,40 +6,27 @@ allowed-paths:
 - pool
 - beam-mysql.cabal
 - LICENSE
-
+allow-newer: true
 
 dependencies:
   euler-build:
-    branch: master
-    revision: aa20a46b6ae5d638c23fa009fb1dd9b07727ffa2
-  beam:
-    branch: master
-    revision: d36b29726570b6c5d228bee44d169282fe99ebdb
+    branch: ghc924
+    revision: 9943d5f7013ce32efcc9920773b204c6fcf0ebc8
 
 overrides:
-  record-dot-preprocessor:
-    version: 0.2.7
-    sha256: 0dyn5wpn0p4sc1yw4zq9awrl2aa3gd3jamllfxrg31v3i3l6jvbw
-    source: hackage
-
-  bytestring-lexing:
+  word24:
+    owner: winterland1989
+    repo: word24
+    branch: master
     source: github
-    owner: juspay
-    repo: bytestring-lexing
-    commit: 0a46db1139011736687cb50bbd3877d223bcb737
-    sha256: 1jrwhlp8xs4m21xfr843278j3i7h4sxyjpq67l6lzc36pqan9zlz
+    commit: 445f791e35ddc8098f05879dbcd07c41b115cb39
+    sha256: 19xm3w8f7kyr6g5rhnywis2piwjzc4wjfspsjrp91qq99gbx4zjb
+  wire-streams:
+    jailbreak: true
+  binary-parsers:
+    jailbreak: true
   mysql-haskell:
-    source: github
-    owner: juspay
-    repo: mysql-haskell
-    commit: 788022d65538db422b02ecc0be138b862d2e5cee
-    sha256: 030qq1hgh15zkwa6j6x568d248iyfaw5idj2hh2mvb7j8xd1l4lv
-  binary-parsers: {}
-  wire-streams: {}
-  mason:
-    source: hackage
-    version: 0.2.3
-    sha256: 1dcd3n1lxlpjsz92lmr1nsx29mwwglim0gask04668sdiarr3x1v
+    jailbreak: true
 
 build-tools:
 - coreutils
@@ -49,7 +36,7 @@ build-tools:
 # - numactl
 
 nix-shell-tools:
-- mysql57
+- mysql80
 - zlib
 # - haskellPackages.cabal-fmt
 # - ghcide
@@ -58,7 +45,7 @@ nix-shell-tools:
 custom-nix:
   insert-binding: |-
     isDarwin = super.stdenv.isDarwin;
-    linuxBuildTools = with super; lib.optionals (!isDarwin) [ mysql57 numactl ];
+    linuxBuildTools = with super; lib.optionals (!isDarwin) [ mysql80 numactl ];
     dontCheckDarwin =
       if isDarwin then super.haskell.lib.dontCheck else x: x;
 

--- a/euler.yaml
+++ b/euler.yaml
@@ -6,12 +6,15 @@ allowed-paths:
 - pool
 - beam-mysql.cabal
 - LICENSE
-allow-newer: true
+
 
 dependencies:
   euler-build:
     branch: ghc924
     revision: 9943d5f7013ce32efcc9920773b204c6fcf0ebc8
+  beam:
+    branch: master
+    revision: 53c98520169472d288bc987a4b7731966348de0b
 
 overrides:
   word24:
@@ -21,11 +24,28 @@ overrides:
     source: github
     commit: 445f791e35ddc8098f05879dbcd07c41b115cb39
     sha256: 19xm3w8f7kyr6g5rhnywis2piwjzc4wjfspsjrp91qq99gbx4zjb
-  wire-streams:
+  record-dot-preprocessor:
+    version: 0.2.15
+    source: hackage
+    sha256: 1kah6infl4nyzabd63g5cllcx5rg0vsp6shml435bvam9yhvbqg5
+
+  bytestring-lexing:
+    source: github
+    owner: juspay
+    repo: bytestring-lexing
+    commit: 0a46db1139011736687cb50bbd3877d223bcb737
+    sha256: 1jrwhlp8xs4m21xfr843278j3i7h4sxyjpq67l6lzc36pqan9zlz
+    jailbreak: true
+  mysql-haskell:
+    source: github
+    owner: juspay
+    repo: mysql-haskell
+    commit: 788022d65538db422b02ecc0be138b862d2e5cee
+    sha256: 030qq1hgh15zkwa6j6x568d248iyfaw5idj2hh2mvb7j8xd1l4lv
     jailbreak: true
   binary-parsers:
     jailbreak: true
-  mysql-haskell:
+  wire-streams:
     jailbreak: true
 
 build-tools:
@@ -54,4 +74,5 @@ custom-nix:
       dontCheckDarwin (super.haskell.lib.addBuildTools (
     right: |-
       ) linuxBuildTools)
+
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,24 +1,5 @@
 {
   "nodes": {
-    "beam": {
-      "inputs": {
-        "euler-build": [
-          "euler-build"
-        ]
-      },
-      "locked": {
-        "lastModified": 1608124323,
-        "narHash": "sha256-5+FseBBqkpoRP+e5Yo1hZlUuxT/Elh7JQjcHSbMZ/DQ=",
-        "owner": "juspay",
-        "repo": "beam",
-        "rev": "d36b29726570b6c5d228bee44d169282fe99ebdb",
-        "type": "github"
-      },
-      "original": {
-        "id": "beam",
-        "type": "indirect"
-      }
-    },
     "euler-build": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -26,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1611066903,
-        "narHash": "sha256-W6TW3VUboJeEuanClxs/ZK59Lxavq4toO9H5VlLdXTw=",
-        "ref": "master",
-        "rev": "aa20a46b6ae5d638c23fa009fb1dd9b07727ffa2",
-        "revCount": 27,
+        "lastModified": 1675855074,
+        "narHash": "sha256-/U2CScTvPmJqAe9NFdNaBsVHx9Yex0vCS9MjKYiPZ+E=",
+        "ref": "ghc924",
+        "rev": "9943d5f7013ce32efcc9920773b204c6fcf0ebc8",
+        "revCount": 45,
         "type": "git",
         "url": "ssh://git@bitbucket.org/juspay/euler-build"
       },
@@ -75,23 +56,22 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1607690238,
-        "narHash": "sha256-9QFXxj6pjmHr+950E3/gXo9cz50l0AbFCHZR5eixkXw=",
+        "lastModified": 1675698036,
+        "narHash": "sha256-BgsQkQewdlQi8gapJN4phpxkI/FCE/2sORBaFcYbp/A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8006772a054ce57ca18c5955dcd6ec9a62577473",
+        "rev": "1046c7b92e908a1202c0f1ba3fc21d19e1cf1b62",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8006772a054ce57ca18c5955dcd6ec9a62577473",
+        "rev": "1046c7b92e908a1202c0f1ba3fc21d19e1cf1b62",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "beam": "beam",
         "euler-build": "euler-build"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,24 @@
 {
   "nodes": {
+    "beam": {
+      "inputs": {
+        "euler-build": [
+          "euler-build"
+        ]
+      },
+      "locked": {
+        "lastModified": 1689945547,
+        "narHash": "sha256-j+FvDpER3gqthBwujjlpCrKLWOS+SxbunlS9GIzPi7k=",
+        "owner": "shivaraj-bh",
+        "repo": "beam",
+        "rev": "53c98520169472d288bc987a4b7731966348de0b",
+        "type": "github"
+      },
+      "original": {
+        "id": "beam",
+        "type": "indirect"
+      }
+    },
     "euler-build": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -13,7 +32,7 @@
         "rev": "9943d5f7013ce32efcc9920773b204c6fcf0ebc8",
         "revCount": 45,
         "type": "git",
-        "url": "ssh://git@bitbucket.org/juspay/euler-build"
+        "url": "ssh://git@ssh.bitbucket.juspay.net/jbiz/euler-build"
       },
       "original": {
         "id": "euler-build",
@@ -72,6 +91,7 @@
     },
     "root": {
       "inputs": {
+        "beam": "beam",
         "euler-build": "euler-build"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,8 @@
   inputs = {
     # Laziness of nix allows us to be lazy here and avoid resolving deps
     # The downside is that most of this .follows are redundant
-    
+    euler-build.inputs.beam.follows = "beam";
+    beam.inputs.euler-build.follows = "euler-build";
   };
 
   outputs = flakeInputs@{ self, euler-build, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,7 @@
   inputs = {
     # Laziness of nix allows us to be lazy here and avoid resolving deps
     # The downside is that most of this .follows are redundant
-    euler-build.inputs.beam.follows = "beam";
-    beam.inputs.euler-build.follows = "euler-build";
+    
   };
 
   outputs = flakeInputs@{ self, euler-build, ... }:
@@ -22,7 +21,7 @@
           "beam-mysql"
         ];
         shellTools = with nixpkgs; [
-          mysql57
+          mysql80
           zlib
         ];
         # shellAttrs = {

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -20,6 +20,18 @@ let
   };
   word24-path = word24-repo;
 
+  bytestring-lexing-repo = builtins.fetchTarball {
+    url = "https://github.com/juspay/bytestring-lexing/archive/0a46db1139011736687cb50bbd3877d223bcb737.tar.gz";
+    sha256 = "1jrwhlp8xs4m21xfr843278j3i7h4sxyjpq67l6lzc36pqan9zlz";
+  };
+  bytestring-lexing-path = bytestring-lexing-repo;
+
+  mysql-haskell-repo = builtins.fetchTarball {
+    url = "https://github.com/juspay/mysql-haskell/archive/788022d65538db422b02ecc0be138b862d2e5cee.tar.gz";
+    sha256 = "030qq1hgh15zkwa6j6x568d248iyfaw5idj2hh2mvb7j8xd1l4lv";
+  };
+  mysql-haskell-path = mysql-haskell-repo;
+
   isDarwin = super.stdenv.isDarwin;
 linuxBuildTools = with super; lib.optionals (!isDarwin) [ mysql80 numactl ];
 dontCheckDarwin =
@@ -30,14 +42,24 @@ super.eulerBuild.mkEulerHaskellOverlay self super
     word24 = self.eulerBuild.fastBuildExternal {
       drv = super.haskell.lib.unmarkBroken (hself.callCabal2nix "word24" word24-path { });
     };
-    wire-streams = self.eulerBuild.fastBuildExternal {
-      drv = self.haskell.lib.doJailbreak (super.haskell.lib.unmarkBroken (hsuper.wire-streams));
+    record-dot-preprocessor = self.eulerBuild.fastBuildExternal {
+      drv = super.haskell.lib.unmarkBroken (hself.callHackageDirect {
+        pkg = "record-dot-preprocessor";
+        ver = "0.2.15";
+        sha256 = "1kah6infl4nyzabd63g5cllcx5rg0vsp6shml435bvam9yhvbqg5";
+      } { });
+    };
+    bytestring-lexing = self.eulerBuild.fastBuildExternal {
+      drv = self.haskell.lib.doJailbreak (super.haskell.lib.unmarkBroken (hself.callCabal2nix "bytestring-lexing" bytestring-lexing-path { }));
+    };
+    mysql-haskell = self.eulerBuild.fastBuildExternal {
+      drv = self.haskell.lib.doJailbreak (super.haskell.lib.unmarkBroken (hself.callCabal2nix "mysql-haskell" mysql-haskell-path { }));
     };
     binary-parsers = self.eulerBuild.fastBuildExternal {
       drv = self.haskell.lib.doJailbreak (super.haskell.lib.unmarkBroken (hsuper.binary-parsers));
     };
-    mysql-haskell = self.eulerBuild.fastBuildExternal {
-      drv = self.haskell.lib.doJailbreak (super.haskell.lib.unmarkBroken (hsuper.mysql-haskell));
+    wire-streams = self.eulerBuild.fastBuildExternal {
+      drv = self.haskell.lib.doJailbreak (super.haskell.lib.unmarkBroken (hsuper.wire-streams));
     };
     
     beam-mysql = dontCheckDarwin (super.haskell.lib.addBuildTools (self.eulerBuild.fastBuild {

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -14,50 +14,30 @@ let
     ];
   };
 
-  bytestring-lexing-repo = builtins.fetchTarball {
-    url = "https://github.com/juspay/bytestring-lexing/archive/0a46db1139011736687cb50bbd3877d223bcb737.tar.gz";
-    sha256 = "1jrwhlp8xs4m21xfr843278j3i7h4sxyjpq67l6lzc36pqan9zlz";
+  word24-repo = builtins.fetchTarball {
+    url = "https://github.com/winterland1989/word24/archive/445f791e35ddc8098f05879dbcd07c41b115cb39.tar.gz";
+    sha256 = "19xm3w8f7kyr6g5rhnywis2piwjzc4wjfspsjrp91qq99gbx4zjb";
   };
-  bytestring-lexing-path = bytestring-lexing-repo;
-
-  mysql-haskell-repo = builtins.fetchTarball {
-    url = "https://github.com/juspay/mysql-haskell/archive/788022d65538db422b02ecc0be138b862d2e5cee.tar.gz";
-    sha256 = "030qq1hgh15zkwa6j6x568d248iyfaw5idj2hh2mvb7j8xd1l4lv";
-  };
-  mysql-haskell-path = mysql-haskell-repo;
+  word24-path = word24-repo;
 
   isDarwin = super.stdenv.isDarwin;
-linuxBuildTools = with super; lib.optionals (!isDarwin) [ mysql57 numactl ];
+linuxBuildTools = with super; lib.optionals (!isDarwin) [ mysql80 numactl ];
 dontCheckDarwin =
   if isDarwin then super.haskell.lib.dontCheck else x: x;
 in
 super.eulerBuild.mkEulerHaskellOverlay self super
   (hself: hsuper: {
-    record-dot-preprocessor = self.eulerBuild.fastBuildExternal {
-      drv = super.haskell.lib.unmarkBroken (hself.callHackageDirect {
-        pkg = "record-dot-preprocessor";
-        ver = "0.2.7";
-        sha256 = "0dyn5wpn0p4sc1yw4zq9awrl2aa3gd3jamllfxrg31v3i3l6jvbw";
-      } { });
-    };
-    bytestring-lexing = self.eulerBuild.fastBuildExternal {
-      drv = super.haskell.lib.unmarkBroken (hself.callCabal2nix "bytestring-lexing" bytestring-lexing-path { });
-    };
-    mysql-haskell = self.eulerBuild.fastBuildExternal {
-      drv = super.haskell.lib.unmarkBroken (hself.callCabal2nix "mysql-haskell" mysql-haskell-path { });
-    };
-    binary-parsers = self.eulerBuild.fastBuildExternal {
-      drv = super.haskell.lib.unmarkBroken (hsuper.binary-parsers);
+    word24 = self.eulerBuild.fastBuildExternal {
+      drv = super.haskell.lib.unmarkBroken (hself.callCabal2nix "word24" word24-path { });
     };
     wire-streams = self.eulerBuild.fastBuildExternal {
-      drv = super.haskell.lib.unmarkBroken (hsuper.wire-streams);
+      drv = self.haskell.lib.doJailbreak (super.haskell.lib.unmarkBroken (hsuper.wire-streams));
     };
-    mason = self.eulerBuild.fastBuildExternal {
-      drv = super.haskell.lib.unmarkBroken (hself.callHackageDirect {
-        pkg = "mason";
-        ver = "0.2.3";
-        sha256 = "1dcd3n1lxlpjsz92lmr1nsx29mwwglim0gask04668sdiarr3x1v";
-      } { });
+    binary-parsers = self.eulerBuild.fastBuildExternal {
+      drv = self.haskell.lib.doJailbreak (super.haskell.lib.unmarkBroken (hsuper.binary-parsers));
+    };
+    mysql-haskell = self.eulerBuild.fastBuildExternal {
+      drv = self.haskell.lib.doJailbreak (super.haskell.lib.unmarkBroken (hsuper.mysql-haskell));
     };
     
     beam-mysql = dontCheckDarwin (super.haskell.lib.addBuildTools (self.eulerBuild.fastBuild {


### PR DESCRIPTION
This PR consists of dependency overrides that support GHC 9.x and using mysql80, as mysql57 is no longer supported.