### PR TITLE
Update dependencies in flake files to use Juspay upstream

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -11,16 +11,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1693307537,
+        "lastModified": 1696055201,
         "narHash": "sha256-BIq3ZjZQWQ0w3zWA19zGBggiVVfnOzR5d4b7De0oVZY=",
-        "owner": "arjunkathuria",
+        "owner": "juspay",
         "repo": "beam",
-        "rev": "06bcc50997fdcfb87125bed252e888e5dd1e6d9c",
+        "rev": "c4f86057db76640245c3d1fde040176c53e9b9a3",
         "type": "github"
       },
       "original": {
-        "owner": "arjunkathuria",
-        "ref": "GHC-927-Upgrade",
+        "owner": "juspay",
         "repo": "beam",
         "type": "github"
       }
@@ -122,16 +121,15 @@
         "word24": "word24"
       },
       "locked": {
-        "lastModified": 1692868544,
+        "lastModified": 1696055302,
         "narHash": "sha256-UY9HRnqWXv5Ud6pfBa/fPNwjauDYpgzJoLcQb4NuH7I=",
-        "owner": "arjunkathuria",
+        "owner": "juspay",
         "repo": "mysql-haskell",
-        "rev": "2f4861667d19e84474700f32922c97af94f5dfc4",
+        "rev": "0c290a5ec4296e7f74d488cbdeb9f384dfb1f04d",
         "type": "github"
       },
       "original": {
-        "owner": "arjunkathuria",
-        "ref": "GHC-927",
+        "owner": "juspay",
         "repo": "mysql-haskell",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -7,13 +7,11 @@
     bytestring-lexing.url = "github:juspay/bytestring-lexing";
     bytestring-lexing.flake = false;
 
-    ## Use Juspay upstream after PR merged here https://github.com/juspay/mysql-haskell/pull/5
-    mysql-haskell.url = "github:arjunkathuria/mysql-haskell/GHC-927";
+    mysql-haskell.url = "github:juspay/mysql-haskell";
     mysql-haskell.inputs.nixpkgs.follows = "nixpkgs";
     mysql-haskell.inputs.haskell-flake.follows = "haskell-flake";
 
-    ## Use Juspay upstream after PR merged - https://github.com/juspay/beam/pull/21
-    beam.url = "github:arjunkathuria/beam/GHC-927-Upgrade";
+    beam.url = "github:juspay/beam";
     beam.inputs.haskell-flake.follows = "haskell-flake";
     beam.inputs.nixpkgs.follows = "nixpkgs";
 


### PR DESCRIPTION
Use Juspay upstream versions of dependencies now that relevant PRs are merged.

* The GHC 927 PRs for `beam` and `mysql-haskell` repositories got merged upstream to Juspay repos:
  - https://github.com/juspay/beam/pull/21
  - https://github.com/juspay/mysql-haskell/pull/5

* Updates the link in `flake.nix` and ergo `flake.lock` files to use upstream Juspay repositories for respective dependencies now.

* They used to point to my personal forks of these repositories, on account of those in-process PRs.