### PR TITLE
Fixed table_schema rendering

### DIFF
--- a/src/Database/Beam/MySQL/Extra.hs
+++ b/src/Database/Beam/MySQL/Extra.hs
@@ -13,7 +13,6 @@ import           Control.Monad.Reader (MonadReader (ask), asks)
 import           Data.Foldable (traverse_)
 import           Data.Functor.Identity (Identity)
 import           Data.Kind (Type)
-import           Data.Maybe (fromMaybe)
 import           Data.Text (Text, pack)
 import           Data.Time (LocalTime, localTimeToUTC, utc, addLocalTime, utctDayTime)
 import           Data.Text.Lazy (fromStrict, toStrict)
@@ -224,11 +223,11 @@ insertRowReturning ins (TableRowExpression v) query@(Query inner) = do
       liftIO (dbg textual) >> pure conn
     ReleaseEnv conn -> pure conn
   -- Get the names of all primary key columns in the table.
-  pkColNames <- getPkCols conn ins.tableName.name (fromMaybe "schema()" ins.tableName.schema)
+  pkColNames <- getPkCols conn ins.tableName.name ins.tableName.schema
   -- If we don't find anything, abort.
   when (null pkColNames) (noPrimaryKey ins)
   -- Determine if we have an auto-increment column, and if so, what it is
-  mAIColumn <- getAutoIncColumn conn ins.tableName.name (fromMaybe "schema()" ins.tableName.schema)
+  mAIColumn <- getAutoIncColumn conn ins.tableName.name ins.tableName.schema
   -- Run the insert
   res <- liftIO . execute_ conn $ query
   case okAffectedRows res of
@@ -324,14 +323,14 @@ getConnection = MySQLM (asks go)
       DebugEnv _ c -> c
       ReleaseEnv c -> c
 
-getPkCols :: MySQLConn -> Text -> Text -> MySQLM (Vector Text)
-getPkCols conn nam schemaNam = do
+getPkCols :: MySQLConn -> Text -> Maybe Text -> MySQLM (Vector Text)
+getPkCols conn nam mbSchemaName = do
   let query = Query $
         "SELECT key_column_usage.column_name " <>
         "FROM information_schema.key_column_usage " <>
-        "WHERE table_schema = '" <>
-        (encodeUtf8 . fromStrict $ schemaNam) <>
-        "' AND constraint_name = 'PRIMARY' " <>
+        "WHERE table_schema = " <>
+        maybe "schema()" (\sn -> encodeUtf8 . fromStrict $ "'" <> sn <> "'") mbSchemaName <>
+        " AND constraint_name = 'PRIMARY' " <>
         "AND table_name = '" <>
         (encodeUtf8 . fromStrict $ nam) <>
         "';"
@@ -345,14 +344,14 @@ getPkCols conn nam schemaNam = do
       res <- read stream
       pure $ (, (env, stream)) <$> (res >>= (!? 0) >>= extractText)
 
-getAutoIncColumn :: MySQLConn -> Text -> Text -> MySQLM (Maybe Text)
-getAutoIncColumn conn nam schemaNam = do
+getAutoIncColumn :: MySQLConn -> Text -> Maybe Text -> MySQLM (Maybe Text)
+getAutoIncColumn conn nam mbSchemaName = do
   let query = Query $
         "SELECT column_name " <>
         "FROM information_schema.columns " <>
-        "WHERE table_schema = '" <>
-        (encodeUtf8 . fromStrict $ schemaNam) <>
-        "' AND table_name = '" <>
+        "WHERE table_schema = " <>
+        maybe "schema()" (\sn -> encodeUtf8 . fromStrict $ "'" <> sn <> "'") mbSchemaName <>
+        " AND table_name = '" <>
         (encodeUtf8 . fromStrict $ nam) <>
         "' AND extra LIKE 'auto_increment' " <>
         "LIMIT 1;"


### PR DESCRIPTION
table_schema was getting rendered as 'schema()' but it should have been schema() 

Tested schemaName with Just val and Nothing
```
SELECT key_column_usage.column_name FROM information_schema.key_column_usage WHERE table_schema = schema() AND constraint_name = 'PRIMARY' AND table_name = 'order_reference';
SELECT column_name FROM information_schema.columns WHERE table_schema = schema() AND table_name = 'order_reference' AND extra LIKE 'auto_increment' LIMIT 1;

SELECT key_column_usage.column_name FROM information_schema.key_column_usage WHERE table_schema = 'jdb' AND constraint_name = 'PRIMARY' AND table_name = 'order_reference';
SELECT column_name FROM information_schema.columns WHERE table_schema = 'jdb' AND table_name = 'order_reference' AND extra LIKE 'auto_increment' LIMIT 1;
```